### PR TITLE
Add .NET AutoML demo with Prometheus/Grafana setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,19 @@
+# Use a imagem oficial de Dev Container para .NET 8 + Python 3.11 + R no Debian
+FROM mcr.microsoft.com/devcontainers/dotnet:8-bullseye
+
+# Instalar Python 3 e pip (caso não esteja incluído)
+RUN apt-get update \
+    && apt-get install -y python3 python3-pip r-base \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Instalar MLflow para Python
+RUN pip3 install mlflow prometheus-client
+
+# Instalar o pacote mlflow no R
+RUN R -e "install.packages('mlflow', repos='https://cloud.r-project.org/')"
+
+# Instalar cliente Prometheus para .NET (no momento do build do projeto .NET, será feito dotnet add package)
+# Apenas garanta que o ambiente .NET esteja pronto
+
+# Configurar usuário vscode como padrão (imagem já define isso)

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "name": "DevContainer AutoML .NET + Python + R + MLOps",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-dotnettools.csharp",
+        "ms-python.python",
+        "ikappas.r",
+        "ms-azuretools.vscode-docker",
+        "graphviz.graphviz-preview"
+      ]
+    }
+  },
+  "forwardPorts": [
+    5000,
+    9090,
+    3000
+  ],
+  "postCreateCommand": "dotnet restore src/AutoMLDemo/AutoMLDemo.csproj && pip install mlflow prometheus-client && Rscript -e \"install.packages('mlflow', repos='https://cloud.r-project.org/')\"",
+  "remoteUser": "vscode"
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
-# mlflow
+/
+├── .devcontainer/
+│   ├── devcontainer.json          # Configuração do Dev Container
+│   └── Dockerfile                 # Dockerfile base para Dev Container
+├── docker-compose.yml             # Compose para Prometheus e Grafana
+├── prometheus.yml                 # Configuração do Prometheus
+├── src/
+│   └── AutoMLDemo/
+│       ├── AutoMLDemo.csproj      # Projeto .NET
+│       ├── Program.cs             # Código principal de AutoML e métricas
+│       ├── MetricServer.cs        # Servidor Prometheus (exposição de métricas)
+│       └── dataset/
+│           └── movies.csv         # Exemplo de dataset (recomendação de filmes)
+└── README.md
+
+## Como usar
+
+1. Abra o repositório no GitHub Codespaces (ou em VS Code com Remote – Containers).
+2. Aguarde a criação do Dev Container (instala .NET 8, Python, R e pacotes MLflow, prometheus-client).
+3. Coloque o arquivo `movies.csv` em `src/AutoMLDemo/dataset/`.
+4. No terminal integrado do Codespace, execute:
+   ```bash
+   dotnet run --project src/AutoMLDemo/AutoMLDemo.csproj
+   ```
+   Isso iniciará o experimento AutoML, exibirá métricas no console e exporá métricas Prometheus em http://localhost:5000/metrics.
+5. Em outro terminal, inicie Prometheus e Grafana:
+   ```bash
+   docker-compose up -d
+   ```
+6. Acesse o Prometheus em http://localhost:9090 para verificar alvos.
+7. Acesse o Grafana em http://localhost:3000 (usuário padrão: admin / admin).
+   - Adicione um Data Source do tipo Prometheus apontando para http://prometheus:9090.
+   - Crie dashboards para as métricas model_r2 e model_rmse.
+
+Dependências
+- .NET 8 SDK
+- Microsoft.ML (>= 2.0.0)
+- Microsoft.ML.AutoML (preview)
+- prometheus-net (>= 6.0.0)
+- Python 3.x + pacotes: mlflow, prometheus-client
+- R 4.x + pacote: mlflow
+- Docker (para Prometheus e Grafana)
+
+Referências
+- Tutoriais ML.NET AutoML em .NET (Microsoft Docs)
+- Exemplo de recomendação de filmes com Model Builder
+- Prometheus .NET Client
+- Grafana Documentation

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.8'
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - "9090:9090"
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    depends_on:
+      - prometheus
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana-storage:/var/lib/grafana
+volumes:
+  grafana-storage:

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'dotnet_automl'
+    static_configs:
+      - targets: ['host.docker.internal:5000']

--- a/src/AutoMLDemo/AutoMLDemo.csproj
+++ b/src/AutoMLDemo/AutoMLDemo.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Pacotes ML.NET -->
+    <PackageReference Include="Microsoft.ML" Version="2.0.0" />
+    <PackageReference Include="Microsoft.ML.AutoML" Version="0.19.0-preview" />
+    <PackageReference Include="Microsoft.ML.Data" Version="2.0.0" />
+
+    <!-- Cliente Prometheus para .NET -->
+    <PackageReference Include="prometheus-net" Version="6.0.0" />
+  </ItemGroup>
+</Project>

--- a/src/AutoMLDemo/MetricServer.cs
+++ b/src/AutoMLDemo/MetricServer.cs
@@ -1,0 +1,24 @@
+using System.Threading;
+using Prometheus;
+
+namespace AutoMLDemo
+{
+    public static class MetricServer
+    {
+        private static Gauge _r2Gauge = Metrics.CreateGauge("model_r2", "R-squared do modelo (.NET)");
+        private static Gauge _rmseGauge = Metrics.CreateGauge("model_rmse", "RMSE do modelo (.NET)");
+
+        public static void Start(int port = 5000)
+        {
+            // Inicia o servidor HTTP do Prometheus na porta informada
+            var server = new KestrelMetricServer(port: port);
+            server.Start();
+        }
+
+        public static void SetMetrics(double r2, double rmse)
+        {
+            _r2Gauge.Set(r2);
+            _rmseGauge.Set(rmse);
+        }
+    }
+}

--- a/src/AutoMLDemo/Program.cs
+++ b/src/AutoMLDemo/Program.cs
@@ -1,0 +1,74 @@
+using System;
+using Microsoft.ML;
+using Microsoft.ML.AutoML;
+using Microsoft.ML.Data;
+
+namespace AutoMLDemo
+{
+    public class MovieRating
+    {
+        [LoadColumn(0)] public float UserId { get; set; }
+        [LoadColumn(1)] public float MovieId { get; set; }
+        [LoadColumn(2)] public float Label { get; set; }
+        // Inclua outras colunas de atributos do dataset conforme necessidade
+    }
+
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            // 1. Iniciar MetricServer para expor métricas Prometheus
+            MetricServer.Start(port: 5000);
+
+            // 2. Criar MLContext
+            var mlContext = new MLContext(seed: 0);
+
+            // 3. Carregar dados
+            string datasetPath = "dataset/movies.csv"; // ajuste conforme localização real do CSV
+            IDataView data = mlContext.Data.LoadFromTextFile<MovieRating>(
+                path: datasetPath,
+                hasHeader: true,
+                separatorChar: ',');
+
+            // 4. Dividir em treino e teste
+            var split = mlContext.Data.TrainTestSplit(data, testFraction: 0.2);
+
+            // 5. Configurar experimento AutoML para regressão
+            var experimentSettings = new RegressionExperimentSettings
+            {
+                MaxExperimentTimeInSeconds = 60,
+                OptimizingMetric = RegressionMetric.RSquared
+            };
+            var experiment = mlContext.Auto().CreateRegressionExperiment(experimentSettings);
+
+            Console.WriteLine("Iniciando experimento AutoML para regressão...");
+            var result = experiment.Execute(trainData: split.TrainSet, labelColumnName: "Label");
+            Console.WriteLine($"Melhor modelo encontrado: {result.BestRun.TrainerName}");
+            Console.WriteLine($"Métricas no conjunto de treino: R² = {result.BestRun.ValidationMetrics.RSquared:F4}, RMSE = {result.BestRun.ValidationMetrics.RootMeanSquaredError:F4}");
+
+            // 6. Avaliar melhor modelo no conjunto de teste
+            var model = result.BestRun.Model;
+            var predictions = model.Transform(split.TestSet);
+            var metrics = mlContext.Regression.Evaluate(predictions, labelColumnName: "Label");
+
+            Console.WriteLine($"Avaliação no conjunto de teste: R² = {metrics.RSquared:F4}, RMSE = {metrics.RootMeanSquaredError:F4}");
+
+            // 7. Atualizar métricas Prometheus
+            MetricServer.SetMetrics(r2: metrics.RSquared, rmse: metrics.RootMeanSquaredError);
+
+            // 8. Fazer uma predição de exemplo
+            var predictionEngine = mlContext.Model.CreatePredictionEngine<MovieRating, MovieRatingPrediction>(model);
+            var sample = new MovieRating { UserId = 1, MovieId = 10 };
+            var prediction = predictionEngine.Predict(sample);
+            Console.WriteLine($"Predição de nota para usuário 1 no filme 10: {prediction.Score:F4}");
+
+            Console.WriteLine("Pressione qualquer tecla para encerrar...");
+            Console.ReadKey();
+        }
+    }
+
+    public class MovieRatingPrediction
+    {
+        public float Score { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- add devcontainer for .NET + Python + R
- add Dockerfile for devcontainer
- add docker-compose with Prometheus and Grafana
- add Prometheus scraping config
- create AutoML demo project with Prometheus metrics
- document usage in README

## Testing
- `dotnet build src/AutoMLDemo/AutoMLDemo.csproj -nologo` *(fails: command not found)*
- `docker-compose --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68425834a120832883c14a3d8c095d46